### PR TITLE
  feat: add cosmos/evm v0.5+ MsgEthereumTx proto for XPLA v1.9.0                

### DIFF
--- a/app/src/main/java/io/delightlabs/xplaandroid/LCDClient.kt
+++ b/app/src/main/java/io/delightlabs/xplaandroid/LCDClient.kt
@@ -2,7 +2,6 @@ package io.delightlabs.xplaandroid
 
 import WasmGRPC
 import cosmos.base.v1beta1.CoinOuterClass.Coin
-import cosmos.base.v1beta1.coin
 import io.delightlabs.xplaandroid.api.APIRequester
 import io.delightlabs.xplaandroid.api.AuthAPI
 import io.delightlabs.xplaandroid.api.BankAPI

--- a/app/src/main/java/io/delightlabs/xplaandroid/LCDWallet.kt
+++ b/app/src/main/java/io/delightlabs/xplaandroid/LCDWallet.kt
@@ -55,6 +55,7 @@ object TypeRegistrySingleton {
                 cosmos.authz.v1beta1.Tx.getDescriptor(),
                 cosmwasm.wasm.v1.Tx.getDescriptor(),
                 ethermint.evm.v1.Tx.getDescriptor(),
+                cosmos.evm.vm.v1.Tx.getDescriptor(),
                 ethermint.feemarket.v1.Tx.getDescriptor(),
                 xpla.reward.v1beta1.Tx.getDescriptor(),
                 xpla.volunteer.v1beta1.Tx.getDescriptor(),

--- a/app/src/main/proto/cosmos/evm/vm/v1/tx.proto
+++ b/app/src/main/proto/cosmos/evm/vm/v1/tx.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+package cosmos.evm.vm.v1;
+
+import "amino/amino.proto";
+import "cosmos/msg/v1/msg.proto";
+import "gogoproto/gogo.proto";
+import "google/api/annotations.proto";
+
+option go_package = "github.com/cosmos/evm/x/vm/types";
+
+// Msg defines the evm Msg service.
+service Msg {
+  option (cosmos.msg.v1.service) = true;
+  // EthereumTx defines a method submitting Ethereum transactions.
+  rpc EthereumTx(MsgEthereumTx) returns (MsgEthereumTxResponse) {
+    option (google.api.http).post = "/cosmos/evm/vm/v1/ethereum_tx";
+  };
+}
+
+// MsgEthereumTx encapsulates an Ethereum transaction as an SDK message.
+message MsgEthereumTx {
+  option (amino.name) = "cosmos/evm/MsgEthereumTx";
+
+  option (gogoproto.goproto_getters) = false;
+
+  reserved 1, 2, 3, 4;
+
+  // from is the bytes of ethereum signer address. This address value is checked
+  // against the address derived from the signature (V, R, S) using the
+  // secp256k1 elliptic curve
+  bytes from = 5;
+  // raw is the raw ethereum transaction
+  bytes raw = 6;
+}
+
+// ExtensionOptionsEthereumTx is an extension option for ethereum transactions
+message ExtensionOptionsEthereumTx {
+  option (gogoproto.goproto_getters) = false;
+}
+
+// MsgEthereumTxResponse defines the Msg/EthereumTx response type.
+message MsgEthereumTxResponse {
+  option (gogoproto.goproto_getters) = false;
+
+  // hash of the ethereum transaction in hex format.
+  string hash = 1;
+  // ret is the returned data from evm function (result or data supplied with revert
+  // opcode)
+  bytes ret = 3;
+  // vm_error is the error returned by vm execution
+  string vm_error = 4;
+  // gas_used specifies how much gas was consumed by the transaction
+  uint64 gas_used = 5;
+}

--- a/app/src/test/java/io/delightlabs/xplaandroid/MsgEthereumTxTest.kt
+++ b/app/src/test/java/io/delightlabs/xplaandroid/MsgEthereumTxTest.kt
@@ -1,0 +1,109 @@
+package io.delightlabs.xplaandroid
+
+import com.google.protobuf.Any
+import com.google.protobuf.ByteString
+import com.google.protobuf.util.JsonFormat
+import org.junit.Assert.*
+import org.junit.Test
+
+class MsgEthereumTxTest {
+
+    /**
+     * TypeRegistry에 cosmos/evm MsgEthereumTx가 정상 등록되었는지 확인
+     */
+    @Test
+    fun testTypeRegistryContainsNewMsgEthereumTx() {
+        val registry = TypeRegistrySingleton.typeRegistry
+
+        // 새 cosmos/evm MsgEthereumTx type URL로 찾을 수 있어야 함
+        val descriptor = registry.find(
+            registry.getDescriptorForTypeUrl("type.googleapis.com/cosmos.evm.vm.v1.MsgEthereumTx")
+                .fullName
+        )
+        assertNotNull("cosmos.evm.vm.v1.MsgEthereumTx should be registered", descriptor)
+    }
+
+    /**
+     * MsgEthereumTx 형태로 오는 JSON 응답을 정상 처리할 수 있는지 확인
+     */
+    @Test
+    fun testNewMsgEthereumTxJsonConversion() {
+        val fromBytes = ByteString.copyFrom(
+            byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05)
+        )
+        val rawBytes = ByteString.copyFrom(
+            byteArrayOf(0xf8.toByte(), 0x65.toByte())
+        )
+
+        val msg = cosmos.evm.vm.v1.Tx.MsgEthereumTx.newBuilder()
+            .setFrom(fromBytes)
+            .setRaw(rawBytes)
+            .build()
+
+        // Any로 감싸기
+        val anyMsg = Any.newBuilder()
+            .setTypeUrl("/cosmos.evm.vm.v1.MsgEthereumTx")
+            .setValue(msg.toByteString())
+            .build()
+
+        // JSON 출력 (TypeRegistry 사용)
+        val jsonPrinter = JsonFormat.printer()
+            .usingTypeRegistry(TypeRegistrySingleton.typeRegistry)
+
+        val json = jsonPrinter.print(anyMsg)
+        assertTrue("JSON should contain type URL", json.contains("cosmos.evm.vm.v1.MsgEthereumTx"))
+        assertTrue("JSON should contain from field", json.contains("from"))
+
+        // JSON -> Any 역변환
+        val builder = Any.newBuilder()
+        JsonFormat.parser()
+            .usingTypeRegistry(TypeRegistrySingleton.typeRegistry)
+            .merge(json, builder)
+        val restored = builder.build()
+
+        assertEquals("/cosmos.evm.vm.v1.MsgEthereumTx", restored.typeUrl)
+    }
+
+    /**
+     * 기존 ethermint MsgEthereumTx도 여전히 TypeRegistry에서 동작하는지 확인
+     */
+    @Test
+    fun testOldEthermintMsgEthereumTxStillWorks() {
+        val registry = TypeRegistrySingleton.typeRegistry
+
+        val descriptor = registry.find(
+            registry.getDescriptorForTypeUrl("type.googleapis.com/ethermint.evm.v1.MsgEthereumTx")
+                .fullName
+        )
+        assertNotNull("ethermint.evm.v1.MsgEthereumTx should still be registered", descriptor)
+    }
+
+    /**
+     * Cube 테스트넷 실제 EVM TX 응답 JSON 파싱 테스트
+     * TX: 276349708750F9737473DF8B8CA6622D79A01B8E14443A8873398C89E8849CEF
+     */
+    @Test
+    fun testParseCubeEvmTxResponse() {
+        val msgJson = """
+            {
+                "@type": "/cosmos.evm.vm.v1.MsgEthereumTx",
+                "from": "5pRRwCc428tPXHPIFaCWvZER7EQ=",
+                "raw": "0x02f8772f8204b88541314cf0008541314cf000830186a094e69451c02738dbcb4f5c73c815a096bd9111ec44880de0b6b3a764000080c080a0f12b1b7b8d7056139083b475405f3a153b3b83033f51b3f13570c0a29a2213f5a04303c4660648e3e14d25eda0ed724857fbcd4b5e84a69e7db511680208b1611d"
+            }
+        """.trimIndent()
+
+        // JSON -> Any 파싱
+        val builder = Any.newBuilder()
+        JsonFormat.parser()
+            .usingTypeRegistry(TypeRegistrySingleton.typeRegistry)
+            .merge(msgJson, builder)
+        val anyMsg = builder.build()
+
+        assertEquals("/cosmos.evm.vm.v1.MsgEthereumTx", anyMsg.typeUrl)
+
+        // Any -> MsgEthereumTx 역직렬화
+        val msg = cosmos.evm.vm.v1.Tx.MsgEthereumTx.parseFrom(anyMsg.value)
+        assertFalse("from should not be empty", msg.from.isEmpty)
+        assertFalse("raw should not be empty", msg.raw.isEmpty)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ buildscript {
 }
 
 plugins {
-    id("com.android.application") version "8.2.2" apply false
+    id("com.android.application") version "8.5.2" apply false
     id("org.jetbrains.kotlin.android") version "1.9.22" apply false
-    id("com.android.library") version "8.2.2" apply false
+    id("com.android.library") version "8.5.2" apply false
 }
 val walletCoreVersion by extra("4.0.28")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Mar 13 14:14:00 KST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
                                                                                                               
  Description:                                                                                                                                                      
  ## Summary                                                                                                                                                        
  - Add `cosmos.evm.vm.v1.MsgEthereumTx` proto file for cosmos/evm v0.5+ (XPLA v1.9.0)                                   
  - Register new descriptor in TypeRegistry for JSON parsing support
  - Keep legacy `ethermint.evm.v1.MsgEthereumTx` for backward compatibility
  - Upgrade Gradle 8.2 → 8.7 and AGP 8.2.2 → 8.5.2 (Java 21 support)